### PR TITLE
Update BuildASS.swift

### DIFF
--- a/Plugins/BuildFFmpeg/BuildASS.swift
+++ b/Plugins/BuildFFmpeg/BuildASS.swift
@@ -71,7 +71,6 @@ class BuildASS: BaseBuild {
                 "--disable-require-system-font-provider",
                 "--disable-test",
                 "--disable-profile",
-                "--disable-coretext",
                 "--with-pic",
                 "--enable-static",
                 "--disable-shared",


### PR DESCRIPTION
Do not disable coretext or add the fontconfig lib, otherwise text subs will not work on MPV.